### PR TITLE
fix: pauwau 2026 admission pricing

### DIFF
--- a/layouts/_default/pauwau.html
+++ b/layouts/_default/pauwau.html
@@ -247,22 +247,21 @@
 		<span class="pw-eyebrow">Plan ahead</span>
 		<h2>Admission</h2>
 		<p>Your admission directly supports the Waccamaw Indian People and the continuation of our cultural programs and traditions.</p>
-		<!-- TODO: confirm {{ $year }} admission pricing with Doug, then replace the $— amounts below. -->
 		<div class="pw-fees">
 			<div class="pw-fee">
-				<div class="pw-fee-amt">$&mdash;</div>
-				<div class="pw-fee-label">General Admission</div>
+				<div class="pw-fee-amt">$10</div>
+				<div class="pw-fee-label">Adults &amp; Kids 15+</div>
 			</div>
 			<div class="pw-fee">
-				<div class="pw-fee-amt">$&mdash;</div>
-				<div class="pw-fee-label">Children (12 &amp; under)</div>
+				<div class="pw-fee-amt">$5</div>
+				<div class="pw-fee-label">Seniors 60+ &amp; Kids 7&ndash;14</div>
 			</div>
 			<div class="pw-fee">
-				<div class="pw-fee-amt">$&mdash;</div>
-				<div class="pw-fee-label">Elders &amp; Veterans</div>
+				<div class="pw-fee-amt">Free</div>
+				<div class="pw-fee-label">Kids 6 &amp; under &middot; Veterans w/ Waccamaw Veterans Feather</div>
 			</div>
 		</div>
-		<p class="pw-note">Admission pricing for the {{ $year }} Pauwau will be confirmed soon. Cash and card accepted at the gate.</p>
+		<p class="pw-note">Cash and card accepted at the gate.</p>
 	</section>
 
 	<!-- VISIT: DIRECTIONS & PARKING -->


### PR DESCRIPTION
## Summary

- Replaces `$—` placeholder fee cards with confirmed 2026 pricing
- Adults & Kids 15+: **$10**
- Seniors 60+ & Kids 7–14: **$5**
- Kids 6 & under / Veterans w/ Waccamaw Veterans Feather: **Free**
- Removes TODO comment and "pricing coming soon" note
- No template/layout structure changes — content values only

## Test plan

- [ ] Verify fee cards render correctly on the `/pauwau/` page
- [ ] Confirm "Cash and card accepted at the gate." note still shows
- [ ] Check mobile layout (cards stack cleanly)