### PR TITLE
feat: Contacts & Directory portal view

### DIFF
--- a/layouts/_default/contacts.html
+++ b/layouts/_default/contacts.html
@@ -1,0 +1,68 @@
+{{ define "main" }}
+<link rel="stylesheet" href="/theme.css?v={{ now.Unix }}">
+<link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+<style>
+  /* Wide data view — break out of the theme's content cap, like the roll book. */
+  main { max-width: none !important; width: auto !important; margin: 0 !important; padding: 0 !important; }
+  .dir-wrap { max-width: none; margin: 0; padding: 1rem 1.5rem; box-sizing: border-box; }
+  .dir-back { display: inline-block; font-size: .85rem; color: #7a5c2e; text-decoration: none; margin-bottom: .15rem; }
+  .dir-back:hover { text-decoration: underline; }
+  #dir-content { height: 100dvh; min-height: 0; display: flex; flex-direction: column; box-sizing: border-box; padding-top: 10px; }
+  .dir-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: .5rem; }
+  .dir-note { color: #666; font-size: .9rem; margin: .25rem 0 .75rem; }
+  .dir-summary { display: flex; gap: .75rem; flex-wrap: wrap; margin: .5rem 0; flex: 0 0 auto; }
+  .dir-stat { background: #f5f3ee; border: 1px solid #e2ddd2; border-radius: 8px; padding: .5rem .9rem; min-width: 92px; }
+  .dir-stat-n { font-size: 1.4rem; font-weight: 700; line-height: 1; }
+  .dir-stat-l { font-size: .75rem; color: #666; text-transform: uppercase; letter-spacing: .03em; }
+  .dir-controls { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; margin: .5rem 0; flex: 0 0 auto; }
+  .dir-controls input[type=text], .dir-controls select { padding: .45rem .6rem; border: 1px solid #ccc; border-radius: 6px; font-size: .95rem; }
+  .dir-main { flex: 1 1 auto; min-height: 0; display: flex; gap: 1rem; }
+  /* lists sidebar */
+  .dir-lists { flex: 0 0 280px; overflow-y: auto; border: 1px solid #e2ddd2; border-radius: 8px; background: #faf8f3; padding: .5rem; }
+  .dir-lists h3 { font-size: .7rem; text-transform: uppercase; letter-spacing: .05em; color: #9b8a66; margin: .6rem .4rem .25rem; }
+  .dir-list-item { display: flex; justify-content: space-between; align-items: center; padding: .3rem .5rem; border-radius: 6px; cursor: pointer; font-size: .9rem; }
+  .dir-list-item:hover { background: #ece5d6; }
+  .dir-list-item.sel { background: #7a5c2e; color: #fff; }
+  .dir-list-item .cnt { font-size: .75rem; color: #998; }
+  .dir-list-item.sel .cnt { color: #e8dcc4; }
+  .dir-list-all { font-weight: 600; }
+  /* grid */
+  #dir-grid { flex: 1 1 auto; min-height: 0; }
+  .pill { display: inline-block; padding: .05rem .45rem; border-radius: 10px; font-size: .75rem; }
+  .pill-member { background: #e3efd9; color: #3a5a22; }
+  .pill-ext { background: #e9e4f3; color: #4a3a6a; }
+  .pill-dnc { background: #f6dada; color: #8a2a2a; }
+  @media (max-width: 800px) { .dir-main { flex-direction: column; } .dir-lists { flex-basis: auto; max-height: 30vh; } }
+</style>
+
+<div class="dir-wrap">
+  <a class="dir-back" href="/members/">← Back to portal</a>
+  <div id="dir-content">
+    <div class="dir-head">
+      <h1 style="margin:0;">Contacts &amp; Directory</h1>
+    </div>
+    <p class="dir-note">Everyone in the tribe's address book — members and external contacts — plus the mailing &amp; committee lists. Members are linked to the tribal roll; edit membership details in the <a href="/members/tribal-roll/">Tribal Roll Book</a>.</p>
+
+    <div class="dir-summary" id="dir-summary"><!-- stats injected --></div>
+
+    <div class="dir-controls">
+      <input type="text" id="dir-search" placeholder="Search name, org, or email…" style="min-width:260px;">
+      <select id="dir-member">
+        <option value="">All contacts</option>
+        <option value="1">Members only</option>
+        <option value="0">External only</option>
+      </select>
+      <span id="dir-active-list" style="font-size:.85rem;color:#7a5c2e;"></span>
+    </div>
+
+    <div class="dir-main">
+      <div class="dir-lists" id="dir-lists"><!-- lists injected --></div>
+      <div id="dir-grid"></div>
+    </div>
+  </div>
+</div>
+
+<script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+<script src="/js/members-config.js?v={{ now.Unix }}"></script>
+<script src="/js/contacts.js?v={{ now.Unix }}"></script>
+{{ end }}

--- a/layouts/_default/contacts.html
+++ b/layouts/_default/contacts.html
@@ -2,23 +2,34 @@
 <link rel="stylesheet" href="/theme.css?v={{ now.Unix }}">
 <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 <style>
-  /* Wide data view — break out of the theme's content cap, like the roll book. */
   main { max-width: none !important; width: auto !important; margin: 0 !important; padding: 0 !important; }
-  .dir-wrap { max-width: none; margin: 0; padding: 1rem 1.5rem; box-sizing: border-box; }
-  .dir-back { display: inline-block; font-size: .85rem; color: #7a5c2e; text-decoration: none; margin-bottom: .15rem; }
+  .dir-wrap { max-width: none; margin: 0; padding: 1rem 1.5rem 0; box-sizing: border-box; }
+  .dir-back { display: inline-block; font-size: .85rem; color: #7a5c2e; text-decoration: none; }
   .dir-back:hover { text-decoration: underline; }
-  #dir-content { height: 100dvh; min-height: 0; display: flex; flex-direction: column; box-sizing: border-box; padding-top: 10px; }
-  .dir-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: .5rem; }
-  .dir-note { color: #666; font-size: .9rem; margin: .25rem 0 .75rem; }
-  .dir-summary { display: flex; gap: .75rem; flex-wrap: wrap; margin: .5rem 0; flex: 0 0 auto; }
-  .dir-stat { background: #f5f3ee; border: 1px solid #e2ddd2; border-radius: 8px; padding: .5rem .9rem; min-width: 92px; }
-  .dir-stat-n { font-size: 1.4rem; font-weight: 700; line-height: 1; }
-  .dir-stat-l { font-size: .75rem; color: #666; text-transform: uppercase; letter-spacing: .03em; }
-  .dir-controls { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; margin: .5rem 0; flex: 0 0 auto; }
+  .dir-titlewrap h1 { margin: .3rem 0 0; }
+  .dir-note { color: #666; font-size: .9rem; margin: .25rem 0 .5rem; max-width: 760px; }
+
+  /* sticky bar — pills + controls pin to the top once you scroll past the title */
+  #dir-sentinel { height: 1px; }
+  .dir-sticky { position: sticky; top: 0; z-index: 40; background: #fbfaf7; padding: .5rem 0; margin: 0 -1.5rem; padding-left: 1.5rem; padding-right: 1.5rem; border-bottom: 1px solid #e2ddd2; transition: box-shadow .15s; }
+  .dir-sticky.stuck { box-shadow: 0 6px 16px rgba(0,0,0,.08); }
+  .dir-summary { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .dir-stat { background: #f5f3ee; border: 1px solid #e2ddd2; border-radius: 8px; padding: .35rem .8rem; min-width: 84px; cursor: pointer; user-select: none; transition: background .12s, border-color .12s; }
+  .dir-stat:hover { border-color: #c9a96a; }
+  .dir-stat.sel { background: #7a5c2e; border-color: #7a5c2e; }
+  .dir-stat.sel .dir-stat-n, .dir-stat.sel .dir-stat-l { color: #fff; }
+  .dir-stat.dnc.sel { background: #b33; border-color: #b33; }
+  .dir-stat-n { font-size: 1.3rem; font-weight: 700; line-height: 1; }
+  .dir-stat-l { font-size: .72rem; color: #666; text-transform: uppercase; letter-spacing: .03em; }
+  .dir-controls { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; margin-top: .5rem; }
   .dir-controls input[type=text], .dir-controls select { padding: .45rem .6rem; border: 1px solid #ccc; border-radius: 6px; font-size: .95rem; }
-  .dir-main { flex: 1 1 auto; min-height: 0; display: flex; gap: 1rem; }
-  /* lists sidebar */
-  .dir-lists { flex: 0 0 280px; overflow-y: auto; border: 1px solid #e2ddd2; border-radius: 8px; background: #faf8f3; padding: .5rem; }
+  .dir-active-list { font-size: .85rem; color: #7a5c2e; display: inline-flex; align-items: center; gap: .4rem; }
+
+  .dir-main { display: flex; gap: 1rem; align-items: flex-start; padding: .75rem 0 1rem; }
+  .dir-lists-col { flex: 0 0 280px; position: sticky; top: 92px; max-height: calc(100dvh - 110px); display: flex; flex-direction: column; }
+  .dir-lists-head { display: flex; justify-content: space-between; align-items: center; padding: .1rem .2rem .4rem; }
+  .dir-lists-head span { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: #9b8a66; font-weight: 600; }
+  .dir-lists { overflow-y: auto; border: 1px solid #e2ddd2; border-radius: 8px; background: #faf8f3; padding: .5rem; }
   .dir-lists h3 { font-size: .7rem; text-transform: uppercase; letter-spacing: .05em; color: #9b8a66; margin: .6rem .4rem .25rem; }
   .dir-list-item { display: flex; justify-content: space-between; align-items: center; padding: .3rem .5rem; border-radius: 6px; cursor: pointer; font-size: .9rem; }
   .dir-list-item:hover { background: #ece5d6; }
@@ -26,38 +37,129 @@
   .dir-list-item .cnt { font-size: .75rem; color: #998; }
   .dir-list-item.sel .cnt { color: #e8dcc4; }
   .dir-list-all { font-weight: 600; }
-  /* grid */
-  #dir-grid { flex: 1 1 auto; min-height: 0; }
+  #dir-grid { flex: 1 1 auto; min-width: 0; height: calc(100dvh - 110px); }
+
   .pill { display: inline-block; padding: .05rem .45rem; border-radius: 10px; font-size: .75rem; }
   .pill-member { background: #e3efd9; color: #3a5a22; }
   .pill-ext { background: #e9e4f3; color: #4a3a6a; }
   .pill-dnc { background: #f6dada; color: #8a2a2a; }
-  @media (max-width: 800px) { .dir-main { flex-direction: column; } .dir-lists { flex-basis: auto; max-height: 30vh; } }
+  @media (max-width: 800px) { .dir-main { flex-direction: column; } .dir-lists-col { position: static; flex-basis: auto; max-height: none; width: 100%; } #dir-grid { height: 70vh; } }
+
+  .dir-btn { background: #7a5c2e; color: #fff; border: 0; border-radius: 6px; padding: .45rem .8rem; font-size: .9rem; cursor: pointer; }
+  .dir-btn:hover { background: #654a22; }
+  .dir-btn.ghost { background: #ece5d6; color: #5a4420; }
+  .dir-btn.sm { padding: .25rem .55rem; font-size: .8rem; }
+  .dir-btn.danger { background: #b33; }
+  .dir-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,.4); display: none; align-items: flex-start; justify-content: center; z-index: 100; overflow-y: auto; padding: 4vh 1rem; }
+  .dir-modal-bg.open { display: flex; }
+  .dir-modal { background: #fff; border-radius: 10px; width: 560px; max-width: 100%; box-shadow: 0 12px 40px rgba(0,0,0,.3); }
+  .dir-modal-head { display: flex; justify-content: space-between; align-items: center; padding: 1rem 1.25rem; border-bottom: 1px solid #eee; }
+  .dir-modal-head h2 { margin: 0; font-size: 1.2rem; }
+  .dir-modal-x { border: 0; background: none; font-size: 1.4rem; cursor: pointer; color: #888; }
+  .dir-modal-body { padding: 1rem 1.25rem; }
+  .dir-field { margin-bottom: .7rem; }
+  .dir-field label { display: block; font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; color: #998; margin-bottom: .2rem; }
+  .dir-field input, .dir-field select, .dir-field textarea { width: 100%; padding: .45rem .6rem; border: 1px solid #ccc; border-radius: 6px; font-size: .95rem; box-sizing: border-box; }
+  .dir-row2 { display: flex; gap: .6rem; } .dir-row2 > * { flex: 1; }
+  .dir-chip { display: inline-flex; align-items: center; gap: .35rem; background: #ece5d6; border: 1px solid #d8cdb5; border-radius: 12px; padding: .12rem .55rem; font-size: .82rem; margin: .15rem .2rem .15rem 0; }
+  .dir-chip-x { cursor: pointer; color: #9b3030; font-weight: 700; }
+  .dir-modal-foot { display: flex; justify-content: space-between; gap: .5rem; padding: 1rem 1.25rem; border-top: 1px solid #eee; }
+  .dir-addlist { display: flex; gap: .4rem; margin-top: .4rem; }
+  .dir-msg { font-size: .85rem; color: #b33; }
 </style>
 
 <div class="dir-wrap">
   <a class="dir-back" href="/members/">← Back to portal</a>
-  <div id="dir-content">
-    <div class="dir-head">
-      <h1 style="margin:0;">Contacts &amp; Directory</h1>
-    </div>
+  <div class="dir-titlewrap">
+    <h1>Contacts &amp; Directory</h1>
     <p class="dir-note">Everyone in the tribe's address book — members and external contacts — plus the mailing &amp; committee lists. Members are linked to the tribal roll; edit membership details in the <a href="/members/tribal-roll/">Tribal Roll Book</a>.</p>
+  </div>
 
-    <div class="dir-summary" id="dir-summary"><!-- stats injected --></div>
-
+  <div id="dir-sentinel"></div>
+  <div class="dir-sticky" id="dir-sticky">
+    <div class="dir-summary" id="dir-summary"><!-- clickable pills --></div>
     <div class="dir-controls">
-      <input type="text" id="dir-search" placeholder="Search name, org, or email…" style="min-width:260px;">
-      <select id="dir-member">
-        <option value="">All contacts</option>
-        <option value="1">Members only</option>
-        <option value="0">External only</option>
-      </select>
-      <span id="dir-active-list" style="font-size:.85rem;color:#7a5c2e;"></span>
+      <input type="text" id="dir-search" placeholder="Search name, org, or email…" style="min-width:240px;">
+      <button type="button" id="dir-new" class="dir-btn">+ New contact</button>
+      <span class="dir-active-list" id="dir-active-list"></span>
     </div>
+  </div>
 
-    <div class="dir-main">
-      <div class="dir-lists" id="dir-lists"><!-- lists injected --></div>
-      <div id="dir-grid"></div>
+  <div class="dir-main">
+    <div class="dir-lists-col">
+      <div class="dir-lists-head">
+        <span>Lists</span>
+        <button type="button" class="dir-btn ghost sm" id="dir-new-list">+ New list</button>
+      </div>
+      <div class="dir-lists" id="dir-lists"></div>
+    </div>
+    <div id="dir-grid"></div>
+  </div>
+</div>
+
+<!-- Contact edit / create modal -->
+<div class="dir-modal-bg" id="dir-modal-bg">
+  <div class="dir-modal">
+    <div class="dir-modal-head"><h2 id="dir-modal-title">Edit contact</h2><button type="button" class="dir-modal-x" id="dir-modal-x">&times;</button></div>
+    <div class="dir-modal-body">
+      <input type="hidden" id="f-id">
+      <div class="dir-row2">
+        <div class="dir-field"><label>First name</label><input type="text" id="f-first"></div>
+        <div class="dir-field"><label>Last name</label><input type="text" id="f-last"></div>
+      </div>
+      <div class="dir-row2">
+        <div class="dir-field"><label>Organization</label><input type="text" id="f-org"></div>
+        <div class="dir-field"><label>Title</label><input type="text" id="f-title"></div>
+      </div>
+      <div class="dir-row2">
+        <div class="dir-field"><label>Email</label><input type="email" id="f-email"></div>
+        <div class="dir-field"><label>Phone</label><input type="text" id="f-phone"></div>
+      </div>
+      <div class="dir-row2">
+        <div class="dir-field"><label>City</label><input type="text" id="f-city"></div>
+        <div class="dir-field"><label>State</label><input type="text" id="f-state"></div>
+      </div>
+      <div class="dir-field"><label><input type="checkbox" id="f-dnc" style="width:auto;"> Do not contact</label></div>
+      <div class="dir-field" id="f-lists-wrap">
+        <label>Lists</label>
+        <div id="f-lists"></div>
+        <div class="dir-addlist">
+          <select id="f-addlist"><option value="">Add to list…</option></select>
+          <button type="button" class="dir-btn ghost" id="f-addlist-btn">Add</button>
+        </div>
+      </div>
+      <div class="dir-msg" id="f-msg"></div>
+    </div>
+    <div class="dir-modal-foot">
+      <span id="f-member-note" style="font-size:.82rem;color:#888;align-self:center;"></span>
+      <span><button type="button" class="dir-btn ghost" id="f-cancel">Cancel</button> <button type="button" class="dir-btn" id="f-save">Save</button></span>
+    </div>
+  </div>
+</div>
+
+<!-- List create / edit modal -->
+<div class="dir-modal-bg" id="list-modal-bg">
+  <div class="dir-modal">
+    <div class="dir-modal-head"><h2 id="list-modal-title">New list</h2><button type="button" class="dir-modal-x" id="list-modal-x">&times;</button></div>
+    <div class="dir-modal-body">
+      <input type="hidden" id="l-id">
+      <div class="dir-field"><label>Name</label><input type="text" id="l-name" placeholder="e.g. 2027 Pow-Wow Volunteers"></div>
+      <div class="dir-field"><label>Kind</label>
+        <select id="l-kind">
+          <option value="distribution">Mailing / distribution</option>
+          <option value="committee">Committee</option>
+          <option value="governance">Governance</option>
+          <option value="event">Event / pow-wow</option>
+          <option value="external">External org</option>
+          <option value="system">System</option>
+        </select>
+      </div>
+      <div class="dir-field"><label>Description (optional)</label><textarea id="l-desc" rows="2"></textarea></div>
+      <div class="dir-msg" id="l-msg"></div>
+    </div>
+    <div class="dir-modal-foot">
+      <button type="button" class="dir-btn danger" id="l-delete" style="visibility:hidden;">Delete list</button>
+      <span><button type="button" class="dir-btn ghost" id="l-cancel">Cancel</button> <button type="button" class="dir-btn" id="l-save">Save</button></span>
     </div>
   </div>
 </div>

--- a/layouts/_default/members.html
+++ b/layouts/_default/members.html
@@ -169,6 +169,10 @@
                         <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-chart"/></svg>
                         <span class="exec-card-text"><span class="exec-card-title">Engagement Dashboard</span><span class="exec-card-sub">Dues &amp; at-risk member analysis</span></span>
                     </a>
+                    <a href="/members/contacts/" class="exec-card" id="contactsBtn">
+                        <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-book"/></svg>
+                        <span class="exec-card-text"><span class="exec-card-title">Contacts &amp; Directory</span><span class="exec-card-sub">All contacts &amp; mailing lists</span></span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/static/js/contacts.js
+++ b/static/js/contacts.js
@@ -1,0 +1,135 @@
+/**
+ * Contacts & Directory — executive-leadership view.
+ * Talks to contact-service (CONFIG.CONTACT_API_BASE_URL):
+ *   GET /api/admin/lists            -> lists + directory summary
+ *   GET /api/admin/contacts?q&list&member -> directory grid
+ * Auth: Bearer JWT from the member-portal session (same token as the roll book).
+ */
+(function () {
+  const CONFIG = window.CONFIG || {};
+  const BASE = CONFIG.CONTACT_API_BASE_URL;
+  const TOKEN_KEY = (CONFIG.STORAGE_KEYS && CONFIG.STORAGE_KEYS.SESSION_TOKEN) || 'waccamaw_session_token';
+
+  let table = null;
+  let activeList = '';     // slug
+  let searchTerm = '';
+  let memberFilter = '';
+  let searchTimer = null;
+
+  function token() { return localStorage.getItem(TOKEN_KEY); }
+
+  async function api(path) {
+    const headers = { 'Content-Type': 'application/json' };
+    const t = token();
+    if (t) headers['Authorization'] = `Bearer ${t}`;
+    const res = await fetch(`${BASE}${path}`, { headers });
+    if (res.status === 401) { localStorage.removeItem(TOKEN_KEY); window.location.href = '/members/'; return null; }
+    if (res.status === 403) { alert('This area is restricted to executive leadership.'); window.location.href = '/members/'; return null; }
+    return res.json();
+  }
+
+  function esc(s) { return (s == null ? '' : String(s)).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+  function displayName(r) {
+    const nm = [r.first_name, r.last_name].filter(Boolean).join(' ').trim();
+    return nm || r.org_name || '(no name)';
+  }
+
+  function renderSummary(s) {
+    if (!s) return;
+    const el = document.getElementById('dir-summary');
+    const stat = (n, l) => `<div class="dir-stat"><div class="dir-stat-n">${n}</div><div class="dir-stat-l">${l}</div></div>`;
+    el.innerHTML =
+      stat(s.contacts, 'Contacts') + stat(s.members, 'Members') + stat(s.external, 'External') +
+      stat(s.lists, 'Lists') + stat(s.do_not_contact, 'Do-not-contact');
+  }
+
+  const KIND_LABEL = {
+    distribution: 'Mailing / distribution', committee: 'Committees',
+    governance: 'Governance', event: 'Events & pow-wow', external: 'External orgs', system: 'System'
+  };
+
+  function renderLists(lists) {
+    const el = document.getElementById('dir-lists');
+    const byKind = {};
+    lists.forEach(l => { (byKind[l.kind] = byKind[l.kind] || []).push(l); });
+    let html = `<div class="dir-list-item dir-list-all${activeList === '' ? ' sel' : ''}" data-slug="">All contacts</div>`;
+    Object.keys(KIND_LABEL).forEach(kind => {
+      const items = (byKind[kind] || []).filter(l => l.member_count > 0 || kind === 'system');
+      if (!items.length) return;
+      html += `<h3>${KIND_LABEL[kind]}</h3>`;
+      items.sort((a, b) => b.member_count - a.member_count);
+      items.forEach(l => {
+        html += `<div class="dir-list-item${activeList === l.slug ? ' sel' : ''}" data-slug="${esc(l.slug)}" title="${esc(l.name)}">
+          <span>${esc(l.name)}</span><span class="cnt">${l.member_count}</span></div>`;
+      });
+    });
+    el.innerHTML = html;
+    el.querySelectorAll('.dir-list-item').forEach(node => {
+      node.addEventListener('click', () => {
+        activeList = node.getAttribute('data-slug');
+        el.querySelectorAll('.dir-list-item').forEach(n => n.classList.remove('sel'));
+        node.classList.add('sel');
+        const lbl = activeList ? `Filtered by list: ${node.querySelector('span').textContent}` : '';
+        document.getElementById('dir-active-list').textContent = lbl;
+        loadContacts();
+      });
+    });
+  }
+
+  function columns() {
+    return [
+      { title: 'Name', field: 'name', widthGrow: 2, formatter: c => {
+          const r = c.getData();
+          const sub = r.org_title ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_title)}${r.org_name ? ' · ' + esc(r.org_name) : ''}</div>` : (r.org_name ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_name)}</div>` : '');
+          return `<strong>${esc(c.getValue())}</strong>${sub}`;
+        } },
+      { title: 'Type', field: 'is_member', width: 110, formatter: c => {
+          const r = c.getData();
+          if (r.do_not_contact) return '<span class="pill pill-dnc">do-not-contact</span>';
+          return r.is_member ? `<span class="pill pill-member">member${r.trb_id ? ' · ' + esc(r.trb_id) : ''}</span>` : '<span class="pill pill-ext">external</span>';
+        } },
+      { title: 'Email', field: 'email', widthGrow: 2, formatter: c => c.getValue() ? `<a href="mailto:${esc(c.getValue())}">${esc(c.getValue())}</a>` : '<span style="color:#bbb;">—</span>' },
+      { title: 'Phone', field: 'phone', width: 130, formatter: c => esc(c.getValue() || '—') },
+      { title: 'Location', field: 'loc', width: 140, formatter: c => { const r = c.getData(); return esc([r.city, r.state].filter(Boolean).join(', ')); } },
+      { title: 'Lists', field: 'list_count', width: 70, hozAlign: 'center' },
+    ];
+  }
+
+  async function loadContacts() {
+    const params = new URLSearchParams();
+    if (searchTerm) params.set('q', searchTerm);
+    if (activeList) params.set('list', activeList);
+    if (memberFilter) params.set('member', memberFilter);
+    const data = await api(`/api/admin/contacts?${params.toString()}`);
+    if (!data) return;
+    const rows = (data.contacts || []).map(r => ({ ...r, name: displayName(r) }));
+    if (!table) {
+      table = new Tabulator('#dir-grid', {
+        data: rows, columns: columns(), layout: 'fitColumns',
+        height: '100%', placeholder: 'No contacts match.', reactiveData: false,
+      });
+    } else {
+      table.replaceData(rows);
+    }
+  }
+
+  async function init() {
+    if (!token()) { window.location.href = '/members/'; return; }
+    const listsData = await api('/api/admin/lists');
+    if (!listsData) return;
+    renderSummary(listsData.summary);
+    renderLists(listsData.lists || []);
+    await loadContacts();
+
+    document.getElementById('dir-search').addEventListener('input', e => {
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => { searchTerm = e.target.value.trim(); loadContacts(); }, 250);
+    });
+    document.getElementById('dir-member').addEventListener('change', e => {
+      memberFilter = e.target.value; loadContacts();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/static/js/contacts.js
+++ b/static/js/contacts.js
@@ -1,57 +1,60 @@
 /**
- * Contacts & Directory — executive-leadership view.
- * Talks to contact-service (CONFIG.CONTACT_API_BASE_URL):
- *   GET /api/admin/lists            -> lists + directory summary
- *   GET /api/admin/contacts?q&list&member -> directory grid
+ * Contacts & Directory — executive-leadership view (read/write + list management).
+ * contact-service (CONFIG.CONTACT_API_BASE_URL):
+ *   GET    /api/admin/lists
+ *   GET    /api/admin/contacts?q&list&member&dnc
+ *   GET    /api/admin/contacts/:id
+ *   POST/PUT  /api/admin/contacts[/:id]
+ *   POST/PUT/DELETE /api/admin/lists[/:id]
+ *   POST/DELETE     /api/admin/lists/:listId/subscriptions[/:contactId]
  * Auth: Bearer JWT from the member-portal session (same token as the roll book).
  */
 (function () {
-  const CONFIG = window.CONFIG || {};
-  const BASE = CONFIG.CONTACT_API_BASE_URL;
-  const TOKEN_KEY = (CONFIG.STORAGE_KEYS && CONFIG.STORAGE_KEYS.SESSION_TOKEN) || 'waccamaw_session_token';
+  const CFG = (typeof CONFIG !== 'undefined') ? CONFIG : (window.CONFIG || {});
+  const TOKEN_KEY = (CFG.STORAGE_KEYS && CFG.STORAGE_KEYS.SESSION_TOKEN) || 'waccamaw_session_token';
 
-  let table = null;
-  let activeList = '';     // slug
-  let searchTerm = '';
-  let memberFilter = '';
-  let searchTimer = null;
+  let table = null, allLists = [], activeList = '', searchTerm = '', pillFilter = '', searchTimer = null;
+  let current = null;     // contact being edited
+  let lastSummary = null;
 
+  const $ = id => document.getElementById(id);
   function token() { return localStorage.getItem(TOKEN_KEY); }
 
-  async function api(path) {
+  async function api(path, opts = {}) {
     const headers = { 'Content-Type': 'application/json' };
-    const t = token();
-    if (t) headers['Authorization'] = `Bearer ${t}`;
-    const res = await fetch(`${BASE}${path}`, { headers });
+    const t = token(); if (t) headers['Authorization'] = `Bearer ${t}`;
+    const res = await fetch(`${CFG.CONTACT_API_BASE_URL || ''}${path}`, { ...opts, headers });
     if (res.status === 401) { localStorage.removeItem(TOKEN_KEY); window.location.href = '/members/'; return null; }
     if (res.status === 403) { alert('This area is restricted to executive leadership.'); window.location.href = '/members/'; return null; }
-    return res.json();
+    return { res, data: await res.json().catch(() => ({})) };
   }
-
   function esc(s) { return (s == null ? '' : String(s)).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+  function displayName(r) { return [r.first_name, r.last_name].filter(Boolean).join(' ').trim() || r.org_name || '(no name)'; }
 
-  function displayName(r) {
-    const nm = [r.first_name, r.last_name].filter(Boolean).join(' ').trim();
-    return nm || r.org_name || '(no name)';
-  }
-
+  // ---------- clickable summary pills ----------
   function renderSummary(s) {
-    if (!s) return;
-    const el = document.getElementById('dir-summary');
-    const stat = (n, l) => `<div class="dir-stat"><div class="dir-stat-n">${n}</div><div class="dir-stat-l">${l}</div></div>`;
-    el.innerHTML =
-      stat(s.contacts, 'Contacts') + stat(s.members, 'Members') + stat(s.external, 'External') +
-      stat(s.lists, 'Lists') + stat(s.do_not_contact, 'Do-not-contact');
+    if (s) lastSummary = s; s = lastSummary; if (!s) return;
+    const pill = (key, n, l, cls) => `<div class="dir-stat ${cls || ''} ${pillFilter === key ? 'sel' : ''}" data-filter="${key}"><div class="dir-stat-n">${n}</div><div class="dir-stat-l">${l}</div></div>`;
+    $('dir-summary').innerHTML =
+      pill('', s.contacts, 'Contacts') + pill('member', s.members, 'Members') +
+      pill('external', s.external, 'External') +
+      `<div class="dir-stat" style="cursor:default;"><div class="dir-stat-n">${s.lists}</div><div class="dir-stat-l">Lists</div></div>` +
+      pill('dnc', s.do_not_contact, 'Do-not-contact', 'dnc');
+    $('dir-summary').querySelectorAll('.dir-stat[data-filter]').forEach(node =>
+      node.addEventListener('click', () => { pillFilter = node.getAttribute('data-filter'); renderSummary(); loadContacts(); }));
   }
 
-  const KIND_LABEL = {
-    distribution: 'Mailing / distribution', committee: 'Committees',
-    governance: 'Governance', event: 'Events & pow-wow', external: 'External orgs', system: 'System'
-  };
-
+  // ---------- lists sidebar ----------
+  const KIND_LABEL = { distribution: 'Mailing / distribution', committee: 'Committees', governance: 'Governance', event: 'Events & pow-wow', external: 'External orgs', system: 'System' };
+  function setActiveListLabel() {
+    const el = $('dir-active-list');
+    if (!activeList) { el.innerHTML = ''; return; }
+    const l = allLists.find(x => x.slug === activeList);
+    el.innerHTML = `Filtered by list: <b>${esc(l ? l.name : activeList)}</b> <button type="button" class="dir-btn ghost sm" id="dir-edit-list">✎ Edit list</button>`;
+    $('dir-edit-list').addEventListener('click', () => openListModal(l));
+  }
   function renderLists(lists) {
-    const el = document.getElementById('dir-lists');
-    const byKind = {};
+    const el = $('dir-lists'), byKind = {};
     lists.forEach(l => { (byKind[l.kind] = byKind[l.kind] || []).push(l); });
     let html = `<div class="dir-list-item dir-list-all${activeList === '' ? ' sel' : ''}" data-slug="">All contacts</div>`;
     Object.keys(KIND_LABEL).forEach(kind => {
@@ -59,77 +62,148 @@
       if (!items.length) return;
       html += `<h3>${KIND_LABEL[kind]}</h3>`;
       items.sort((a, b) => b.member_count - a.member_count);
-      items.forEach(l => {
-        html += `<div class="dir-list-item${activeList === l.slug ? ' sel' : ''}" data-slug="${esc(l.slug)}" title="${esc(l.name)}">
-          <span>${esc(l.name)}</span><span class="cnt">${l.member_count}</span></div>`;
-      });
+      items.forEach(l => { html += `<div class="dir-list-item${activeList === l.slug ? ' sel' : ''}" data-slug="${esc(l.slug)}" title="${esc(l.name)}"><span>${esc(l.name)}</span><span class="cnt">${l.member_count}</span></div>`; });
     });
     el.innerHTML = html;
-    el.querySelectorAll('.dir-list-item').forEach(node => {
-      node.addEventListener('click', () => {
-        activeList = node.getAttribute('data-slug');
-        el.querySelectorAll('.dir-list-item').forEach(n => n.classList.remove('sel'));
-        node.classList.add('sel');
-        const lbl = activeList ? `Filtered by list: ${node.querySelector('span').textContent}` : '';
-        document.getElementById('dir-active-list').textContent = lbl;
-        loadContacts();
-      });
-    });
+    el.querySelectorAll('.dir-list-item').forEach(node => node.addEventListener('click', () => {
+      activeList = node.getAttribute('data-slug');
+      el.querySelectorAll('.dir-list-item').forEach(n => n.classList.remove('sel'));
+      node.classList.add('sel');
+      setActiveListLabel();
+      loadContacts();
+    }));
+    setActiveListLabel();
   }
 
+  // ---------- grid ----------
   function columns() {
     return [
-      { title: 'Name', field: 'name', widthGrow: 2, formatter: c => {
-          const r = c.getData();
-          const sub = r.org_title ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_title)}${r.org_name ? ' · ' + esc(r.org_name) : ''}</div>` : (r.org_name ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_name)}</div>` : '');
-          return `<strong>${esc(c.getValue())}</strong>${sub}`;
-        } },
-      { title: 'Type', field: 'is_member', width: 110, formatter: c => {
-          const r = c.getData();
-          if (r.do_not_contact) return '<span class="pill pill-dnc">do-not-contact</span>';
-          return r.is_member ? `<span class="pill pill-member">member${r.trb_id ? ' · ' + esc(r.trb_id) : ''}</span>` : '<span class="pill pill-ext">external</span>';
-        } },
-      { title: 'Email', field: 'email', widthGrow: 2, formatter: c => c.getValue() ? `<a href="mailto:${esc(c.getValue())}">${esc(c.getValue())}</a>` : '<span style="color:#bbb;">—</span>' },
+      { title: 'Name', field: 'name', widthGrow: 2, formatter: c => { const r = c.getData(); const sub = r.org_title ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_title)}${r.org_name ? ' · ' + esc(r.org_name) : ''}</div>` : (r.org_name ? `<div style="font-size:.78rem;color:#888;">${esc(r.org_name)}</div>` : ''); return `<strong>${esc(c.getValue())}</strong>${sub}`; } },
+      { title: 'Type', field: 'is_member', width: 120, formatter: c => { const r = c.getData(); if (r.do_not_contact) return '<span class="pill pill-dnc">do-not-contact</span>'; return r.is_member ? `<span class="pill pill-member">member${r.trb_id ? ' · ' + esc(r.trb_id) : ''}</span>` : '<span class="pill pill-ext">external</span>'; } },
+      { title: 'Email', field: 'email', widthGrow: 2, formatter: c => c.getValue() ? esc(c.getValue()) : '<span style="color:#bbb;">—</span>' },
       { title: 'Phone', field: 'phone', width: 130, formatter: c => esc(c.getValue() || '—') },
       { title: 'Location', field: 'loc', width: 140, formatter: c => { const r = c.getData(); return esc([r.city, r.state].filter(Boolean).join(', ')); } },
-      { title: 'Lists', field: 'list_count', width: 70, hozAlign: 'center' },
+      { title: 'Lists', field: 'list_count', width: 64, hozAlign: 'center' },
     ];
   }
-
   async function loadContacts() {
-    const params = new URLSearchParams();
-    if (searchTerm) params.set('q', searchTerm);
-    if (activeList) params.set('list', activeList);
-    if (memberFilter) params.set('member', memberFilter);
-    const data = await api(`/api/admin/contacts?${params.toString()}`);
-    if (!data) return;
-    const rows = (data.contacts || []).map(r => ({ ...r, name: displayName(r) }));
+    const p = new URLSearchParams();
+    if (searchTerm) p.set('q', searchTerm);
+    if (activeList) p.set('list', activeList);
+    if (pillFilter === 'member') p.set('member', '1');
+    else if (pillFilter === 'external') p.set('member', '0');
+    else if (pillFilter === 'dnc') p.set('dnc', '1');
+    const r = await api(`/api/admin/contacts?${p.toString()}`); if (!r) return;
+    const rows = (r.data.contacts || []).map(x => ({ ...x, name: displayName(x) }));
     if (!table) {
-      table = new Tabulator('#dir-grid', {
-        data: rows, columns: columns(), layout: 'fitColumns',
-        height: '100%', placeholder: 'No contacts match.', reactiveData: false,
-      });
-    } else {
-      table.replaceData(rows);
-    }
+      table = new Tabulator('#dir-grid', { data: rows, columns: columns(), layout: 'fitColumns', height: '100%', placeholder: 'No contacts match.' });
+      table.on('rowClick', (e, row) => openContact(row.getData().id));
+    } else { table.replaceData(rows); }
+  }
+
+  // ---------- contact modal ----------
+  function openModal() { $('dir-modal-bg').classList.add('open'); }
+  function closeModal() { $('dir-modal-bg').classList.remove('open'); current = null; }
+  function fill(c) {
+    $('f-id').value = c.id || ''; $('f-first').value = c.first_name || ''; $('f-last').value = c.last_name || '';
+    $('f-org').value = c.org_name || ''; $('f-title').value = c.org_title || ''; $('f-email').value = c.email || '';
+    $('f-phone').value = c.phone || ''; $('f-city').value = c.city || ''; $('f-state').value = c.state || '';
+    $('f-dnc').checked = !!c.do_not_contact; $('f-msg').textContent = '';
+  }
+  function renderModalLists(lists) {
+    const el = $('f-lists');
+    el.innerHTML = (lists && lists.length) ? lists.map(l => `<span class="dir-chip">${esc(l.name)}<span class="dir-chip-x" data-slug="${esc(l.slug)}">&times;</span></span>`).join('') : '<span style="color:#aaa;font-size:.85rem;">No lists</span>';
+    const have = new Set((lists || []).map(l => l.slug));
+    $('f-addlist').innerHTML = '<option value="">Add to list…</option>' + allLists.filter(l => !have.has(l.slug)).map(l => `<option value="${l.id}">${esc(l.name)}</option>`).join('');
+    el.querySelectorAll('.dir-chip-x').forEach(x => x.addEventListener('click', () => unsubscribe(x.getAttribute('data-slug'))));
+  }
+  async function openContact(id) {
+    const r = await api(`/api/admin/contacts/${id}`); if (!r || !r.data.contact) return;
+    current = r.data.contact;
+    $('dir-modal-title').textContent = 'Edit contact'; fill(current);
+    $('f-member-note').textContent = current.is_member ? `Tribal member${current.trb_id ? ' · ' + current.trb_id : ''} — edit roll details in the Roll Book` : '';
+    $('f-lists-wrap').style.display = ''; renderModalLists(r.data.lists); openModal();
+  }
+  function openNew() { current = {}; $('dir-modal-title').textContent = 'New contact'; fill({}); $('f-member-note').textContent = ''; $('f-lists-wrap').style.display = 'none'; openModal(); }
+  async function saveContact() {
+    const body = { first_name: $('f-first').value.trim(), last_name: $('f-last').value.trim(), org_name: $('f-org').value.trim(), org_title: $('f-title').value.trim(), email: $('f-email').value.trim(), phone: $('f-phone').value.trim(), city: $('f-city').value.trim(), state: $('f-state').value.trim(), do_not_contact: $('f-dnc').checked };
+    const id = $('f-id').value;
+    const r = id ? await api(`/api/admin/contacts/${id}`, { method: 'PUT', body: JSON.stringify(body) }) : await api('/api/admin/contacts', { method: 'POST', body: JSON.stringify(body) });
+    if (!r) return;
+    if (!r.res.ok) { $('f-msg').textContent = r.data.error || 'Save failed'; return; }
+    closeModal(); await refresh();
+  }
+  async function subscribe() {
+    const listId = $('f-addlist').value; if (!listId || !current || !current.id) return;
+    const r = await api(`/api/admin/lists/${listId}/subscriptions`, { method: 'POST', body: JSON.stringify({ contact_id: current.id }) });
+    if (r && r.res.ok) { const d = await api(`/api/admin/contacts/${current.id}`); renderModalLists(d.data.lists); reloadListsSidebar(); }
+  }
+  async function unsubscribe(slug) {
+    const list = allLists.find(l => l.slug === slug); if (!list || !current || !current.id) return;
+    const r = await api(`/api/admin/lists/${list.id}/subscriptions/${current.id}`, { method: 'DELETE' });
+    if (r && r.res.ok) { const d = await api(`/api/admin/contacts/${current.id}`); renderModalLists(d.data.lists); reloadListsSidebar(); }
+  }
+
+  // ---------- list modal (create / edit / delete) ----------
+  let editingList = null;
+  function openListModal(list) {
+    editingList = list || null;
+    $('list-modal-title').textContent = list ? 'Edit list' : 'New list';
+    $('l-id').value = list ? list.id : '';
+    $('l-name').value = list ? list.name : '';
+    $('l-kind').value = list ? list.kind : 'distribution';
+    $('l-desc').value = (list && list.description) || '';
+    $('l-msg').textContent = '';
+    $('l-delete').style.visibility = list ? 'visible' : 'hidden';
+    $('list-modal-bg').classList.add('open');
+  }
+  function closeListModal() { $('list-modal-bg').classList.remove('open'); editingList = null; }
+  async function saveList() {
+    const body = { name: $('l-name').value.trim(), kind: $('l-kind').value, description: $('l-desc').value.trim() };
+    if (!body.name) { $('l-msg').textContent = 'Name is required'; return; }
+    const id = $('l-id').value;
+    const r = id ? await api(`/api/admin/lists/${id}`, { method: 'PUT', body: JSON.stringify(body) }) : await api('/api/admin/lists', { method: 'POST', body: JSON.stringify(body) });
+    if (!r) return;
+    if (!r.res.ok) { $('l-msg').textContent = r.data.error || 'Save failed'; return; }
+    closeListModal(); await reloadListsSidebar();
+  }
+  async function deleteList() {
+    const id = $('l-id').value; if (!id) return;
+    if (!confirm('Delete this list and all its memberships? This cannot be undone.')) return;
+    const r = await api(`/api/admin/lists/${id}`, { method: 'DELETE' });
+    if (r && r.res.ok) { if (editingList && editingList.slug === activeList) { activeList = ''; } closeListModal(); await refresh(); }
+  }
+
+  async function reloadListsSidebar() {
+    const r = await api('/api/admin/lists'); if (!r) return;
+    allLists = r.data.lists || []; renderSummary(r.data.summary); renderLists(allLists);
+  }
+  async function refresh() { await reloadListsSidebar(); await loadContacts(); }
+
+  function wireSticky() {
+    const sentinel = $('dir-sentinel'), bar = $('dir-sticky');
+    if (!sentinel || !bar || !('IntersectionObserver' in window)) return;
+    new IntersectionObserver(([e]) => bar.classList.toggle('stuck', !e.isIntersecting), { threshold: 0 }).observe(sentinel);
   }
 
   async function init() {
-    if (!token()) { window.location.href = '/members/'; return; }
-    const listsData = await api('/api/admin/lists');
-    if (!listsData) return;
-    renderSummary(listsData.summary);
-    renderLists(listsData.lists || []);
+    const r = await api('/api/admin/lists'); if (!r) return;
+    allLists = r.data.lists || []; renderSummary(r.data.summary); renderLists(allLists);
     await loadContacts();
-
-    document.getElementById('dir-search').addEventListener('input', e => {
-      clearTimeout(searchTimer);
-      searchTimer = setTimeout(() => { searchTerm = e.target.value.trim(); loadContacts(); }, 250);
-    });
-    document.getElementById('dir-member').addEventListener('change', e => {
-      memberFilter = e.target.value; loadContacts();
-    });
+    wireSticky();
+    $('dir-search').addEventListener('input', e => { clearTimeout(searchTimer); searchTimer = setTimeout(() => { searchTerm = e.target.value.trim(); loadContacts(); }, 250); });
+    $('dir-new').addEventListener('click', openNew);
+    $('dir-new-list').addEventListener('click', () => openListModal(null));
+    $('f-save').addEventListener('click', saveContact);
+    $('f-cancel').addEventListener('click', closeModal);
+    $('dir-modal-x').addEventListener('click', closeModal);
+    $('f-addlist-btn').addEventListener('click', subscribe);
+    $('dir-modal-bg').addEventListener('click', e => { if (e.target === $('dir-modal-bg')) closeModal(); });
+    $('l-save').addEventListener('click', saveList);
+    $('l-cancel').addEventListener('click', closeListModal);
+    $('list-modal-x').addEventListener('click', closeListModal);
+    $('l-delete').addEventListener('click', deleteList);
+    $('list-modal-bg').addEventListener('click', e => { if (e.target === $('list-modal-bg')) closeListModal(); });
   }
-
   document.addEventListener('DOMContentLoaded', init);
 })();

--- a/static/js/members-config.js
+++ b/static/js/members-config.js
@@ -26,7 +26,12 @@ const CONFIG = {
     MEETINGS_API_BASE_URL: window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
         ? 'http://localhost:8789'  // Meetings service port
         : 'https://meetings.waccamaw.org',
-    
+
+    // Contact/Directory API Base URL - Standalone contact service
+    CONTACT_API_BASE_URL: window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+        ? 'http://localhost:8788'  // Contact service port
+        : 'https://contact.waccamaw.org',
+
     // Environment
     ENV: window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
         ? 'development'


### PR DESCRIPTION
Executive-leadership view over the new contact-service directory + lists (pairs with waccamaw/contact-service#1).

## What
- **Exec-tools card** "Contacts & Directory" on the member portal (`layouts/_default/members.html`)
- **`layouts/_default/contacts.html`** — lists sidebar (grouped by kind, click to filter) + contacts grid (Tabulator), summary stats, search, member/external filter. Mirrors the Tribal Roll Book.
- **`static/js/contacts.js`** — calls contact-service `/api/admin/lists` + `/api/admin/contacts` with the portal session JWT; 401/403 → back to portal.
- **`members-config.js`** — `CONTACT_API_BASE_URL` (`contact.waccamaw.org`, localhost:8788 in dev).

## Deploy notes
- Needs **contact-service** deployed with the read API (waccamaw/contact-service#1) and its prod `JWT_SECRET` **matching members-service's** (the portal token is verified there).
- The `/members/contacts/` page is a **micro.blog Page** (repo `content/` is gitignored) — create it like `/members/tribal-roll/` was: layout `contacts`, url `/members/contacts/`.
- Verified: Hugo 0.91 build renders `/members/contacts/` and the exec card; contact-service endpoint SQL validated against live D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)