### PR TITLE
fix: commit /members/contacts/ page (gitignore ate it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,10 @@ content-export*
 content.zip
 *.zip
 
-content/
+# Micro.blog-synced subdirs only (date posts handled above). Do NOT exclude all
+# of content/ — a bare `content/` traps new top-level page sources like
+# content/contacts.md despite `!content/*.md` (a parent-dir exclude can't be negated).
+content/newsletters/
 # Micro.blog syncs data/ (blogrolls, bookshelves, …) — ignore those,
 # but keep hand-authored config like the Pauwau date in the repo.
 data/*

--- a/content/contacts.md
+++ b/content/contacts.md
@@ -1,0 +1,8 @@
+---
+title: "Contacts & Directory"
+date: 2000-11-20T12:00:00-05:00
+layout: "contacts"
+url: "/members/contacts/"
+hide_donate: true
+hide_footer: true
+---


### PR DESCRIPTION
The contacts view 404s live but works locally because **content/contacts.md was gitignored** by the bare `content/` catch-all — so it never reached the repo micro.blog rebuilds from. The older pages (members.md, tribal-roll.md) were committed before that rule. Narrows the catch-all to `content/newsletters/` and commits the page source. After deploy, /members/contacts/ should build live.