### PR TITLE
fix(contacts view): sticky bar clipping

### DIFF
--- a/layouts/_default/contacts.html
+++ b/layouts/_default/contacts.html
@@ -25,8 +25,10 @@
   .dir-controls input[type=text], .dir-controls select { padding: .45rem .6rem; border: 1px solid #ccc; border-radius: 6px; font-size: .95rem; }
   .dir-active-list { font-size: .85rem; color: #7a5c2e; display: inline-flex; align-items: center; gap: .4rem; }
 
-  .dir-main { display: flex; gap: 1rem; align-items: flex-start; padding: .75rem 0 1rem; }
-  .dir-lists-col { flex: 0 0 280px; position: sticky; top: 92px; max-height: calc(100dvh - 110px); display: flex; flex-direction: column; }
+  /* Below the sticky bar: pin the whole content region under the (measured) bar
+     height and let the columns scroll internally — no magic-number clipping. */
+  .dir-main { display: flex; gap: 1rem; align-items: stretch; position: sticky; top: var(--bar-h, 116px); height: calc(100dvh - var(--bar-h, 116px)); box-sizing: border-box; padding-top: .5rem; }
+  .dir-lists-col { flex: 0 0 280px; height: 100%; display: flex; flex-direction: column; }
   .dir-lists-head { display: flex; justify-content: space-between; align-items: center; padding: .1rem .2rem .4rem; }
   .dir-lists-head span { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: #9b8a66; font-weight: 600; }
   .dir-lists { overflow-y: auto; border: 1px solid #e2ddd2; border-radius: 8px; background: #faf8f3; padding: .5rem; }
@@ -37,13 +39,13 @@
   .dir-list-item .cnt { font-size: .75rem; color: #998; }
   .dir-list-item.sel .cnt { color: #e8dcc4; }
   .dir-list-all { font-weight: 600; }
-  #dir-grid { flex: 1 1 auto; min-width: 0; height: calc(100dvh - 110px); }
+  #dir-grid { flex: 1 1 auto; min-width: 0; height: 100%; }
 
   .pill { display: inline-block; padding: .05rem .45rem; border-radius: 10px; font-size: .75rem; }
   .pill-member { background: #e3efd9; color: #3a5a22; }
   .pill-ext { background: #e9e4f3; color: #4a3a6a; }
   .pill-dnc { background: #f6dada; color: #8a2a2a; }
-  @media (max-width: 800px) { .dir-main { flex-direction: column; } .dir-lists-col { position: static; flex-basis: auto; max-height: none; width: 100%; } #dir-grid { height: 70vh; } }
+  @media (max-width: 800px) { .dir-main { flex-direction: column; position: static; height: auto; } .dir-lists-col { flex-basis: auto; max-height: 40vh; width: 100%; } #dir-grid { height: 70vh; } }
 
   .dir-btn { background: #7a5c2e; color: #fff; border: 0; border-radius: 6px; padding: .45rem .8rem; font-size: .9rem; cursor: pointer; }
   .dir-btn:hover { background: #654a22; }

--- a/static/js/contacts.js
+++ b/static/js/contacts.js
@@ -180,8 +180,14 @@
   }
   async function refresh() { await reloadListsSidebar(); await loadContacts(); }
 
+  function measureBar() {
+    const bar = $('dir-sticky');
+    if (bar) document.documentElement.style.setProperty('--bar-h', bar.offsetHeight + 'px');
+  }
   function wireSticky() {
     const sentinel = $('dir-sentinel'), bar = $('dir-sticky');
+    measureBar();
+    window.addEventListener('resize', measureBar);
     if (!sentinel || !bar || !('IntersectionObserver' in window)) return;
     new IntersectionObserver(([e]) => bar.classList.toggle('stuck', !e.isIntersecting), { threshold: 0 }).observe(sentinel);
   }


### PR DESCRIPTION
The pinned summary bar was overlapping the grid/list headers when scrolled (hand-tuned px offsets were shorter than the actual bar). Now measures the bar height into a `--bar-h` CSS var and pins the content region below it.