### PR TITLE
tribal-roll: core_member checkbox in recordkeeper editor

### DIFF
--- a/layouts/_default/tribal-roll.html
+++ b/layouts/_default/tribal-roll.html
@@ -60,6 +60,7 @@
   .rp-w { background: #fdecd2; color: #8a5a12; }
   .rp-e { background: #e3f3e6; color: #1b7a37; }
   .rp-2 { background: #efe9fb; color: #5b3da8; }
+  .rp-c { background: #fbe0e0; color: #9a2a2a; }
   .roll-edit-btn { font-size: .75rem; padding: .12rem .5rem; border: 1px solid #c9c1b0; border-radius: 6px; background: #fff; cursor: pointer; }
   .roll-edit-btn:hover { background: #f5f3ee; }
   .roll-btn { padding: .45rem .8rem; border: 0; border-radius: 6px; background: #7a5c2e; color: #fff; cursor: pointer; }

--- a/static/js/tribal-roll.js
+++ b/static/js/tribal-roll.js
@@ -40,6 +40,7 @@
     { k: "fee_exempt", l: "Fee exempt", t: "bool" },
     { k: "fee_exemption_type", l: "Exemption reason", t: "enum" },
     { k: "second_chance_used", l: "Second chance used", t: "bool" },
+    { k: "core_member", l: "Core member", t: "bool" },
     { k: "at_risk", l: "At risk", t: "bool" },
     { k: "needs_status_review", l: "Needs review", t: "bool" },
     { k: "voting_eligible", l: "Voting eligible", t: "bool" },
@@ -74,6 +75,7 @@
     { k: "fee_exempt", l: "Fee exempt", t: "check" },
     { k: "fee_exemption_type", l: "Exemption reason", t: "select", opts: EXEMPTION_TYPES },
     { k: "second_chance_used", l: "Second chance used", t: "check" },
+    { k: "core_member", l: "Core member", t: "check" },
     { k: "at_risk", l: "At risk", t: "check" },
     { k: "newsletter_opt_in", l: "Newsletter (paper)", t: "check" },
     { k: "needs_status_review", l: "Needs status review", t: "check" },
@@ -149,7 +151,8 @@
       { title: "Flags", field: "needs_status_review", headerSort: false, width: 205,
         formatter: (cell) => {
           const d = cell.getRow().getData();
-          return (d.voting_eligible ? '<span class="rp rp-v">vote</span>' : "") +
+          return (d.core_member ? '<span class="rp rp-c">core</span>' : "") +
+                 (d.voting_eligible ? '<span class="rp rp-v">vote</span>' : "") +
                  (d.fee_exempt ? '<span class="rp rp-e">exempt</span>' : "") +
                  (d.second_chance_used ? '<span class="rp rp-2">2nd chance</span>' : "") +
                  (d.needs_status_review ? '<span class="rp rp-w">review</span>' : "");
@@ -594,6 +597,7 @@
     { k: "fee_exempt", l: "Fee exempt", t: "bool" },
     { k: "fee_exemption_type", l: "Exemption reason", t: "enum", opts: EXEMPTION_TYPES },
     { k: "second_chance_used", l: "Second chance used", t: "bool" },
+    { k: "core_member", l: "Core member", t: "bool" },
     { k: "portal_acl_tier", l: "Portal tier", t: "enum", opts: TIERS },
     { k: "needs_status_review", l: "Needs review", t: "bool" },
   ];


### PR DESCRIPTION
Surfaces the core_member flag in the Tribal Roll Book editor (recordkeeper-facing half of members-service #8/#10). Adds an editable 'Core member' checkbox to the edit modal, a filter facet, a bulk-set field, and a red 'core' pill in the roster Flags column. Mirrors fee_exempt/second_chance_used. Backend already live: #10 merged, migration 0005 applied to prod D1 (899 rows default 0), Worker redeployed. Needed for BIA reporting and tribal constitutional compliance.