### PR TITLE
updates: rebuild the news index in the museum design language

### DIFF
--- a/layouts/_default/updates.html
+++ b/layouts/_default/updates.html
@@ -1,16 +1,16 @@
 {{ define "main" }}
 
-<div class="updates-feed">
-	<h1 onclick="toggleCategoryFilter()" style="cursor: pointer;">
-		{{ .Title }}
-		<svg class="filter-icon" id="filterIcon" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-			<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
-		</svg>
-	</h1>
-	
+<div class="updates-page">
+
 	{{ $allPosts := where .Site.RegularPages "Type" "post" }}
-	
-	<!-- Category Filter -->
+
+	<header class="updates-header">
+		<span class="updates-kicker">News &amp; Announcements</span>
+		<h1>{{ .Title }}</h1>
+		<p class="updates-lede">{{ .Content | plainify | htmlUnescape | default "Latest news, announcements, and updates from the Waccamaw Indian People." }}</p>
+	</header>
+
+	<!-- Category filter (warm pills) -->
 	{{ $categories := slice }}
 	{{ range $allPosts }}
 		{{ range .Params.categories }}
@@ -18,105 +18,76 @@
 		{{ end }}
 	{{ end }}
 	{{ $categories = $categories | uniq }}
-	
+
 	{{ if $categories }}
-	<div class="category-filter" id="categoryFilter" style="display: none;">
+	<nav class="category-filter" aria-label="Filter updates by category">
 		<div class="category-links">
-			<a href="/updates/" class="category-link">All</a>
+			<a href="/updates/" class="category-link is-active">All</a>
 			{{ range sort $categories }}
 				<a href="/categories/{{ . | urlize }}/" class="category-link">{{ . }}</a>
 			{{ end }}
 		</div>
-	</div>
+	</nav>
 	{{ end }}
 
-	<script>
-	function toggleCategoryFilter() {
-		const filter = document.getElementById('categoryFilter');
-		const icon = document.getElementById('filterIcon');
-		
-		if (filter.style.display === 'none') {
-			filter.style.display = 'block';
-			setTimeout(() => {
-				filter.classList.add('show');
-			}, 10);
-			icon.style.transform = 'rotate(180deg)';
-		} else {
-			filter.classList.remove('show');
-			setTimeout(() => {
-				filter.style.display = 'none';
-			}, 300);
-			icon.style.transform = 'rotate(0deg)';
-		}
-	}
-	</script>
-	
-	<!-- Show first 10 posts -->
+	<!-- First 10 posts as a museum-style collection grid -->
 	{{ $displayPosts := first 10 $allPosts }}
-	
-	{{ range $displayPosts }}
-		<article class="h-entry post-preview">
-			<header class="post-header">
-				{{ if .Title }}
-					<h3 class="p-name post-title">
-						<a href="{{ .Permalink }}">{{ .Title }}</a>
-					</h3>
-				{{ end }}
-				
-				<div class="post-meta">
-					<time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">
-						{{ .Date.Format "January 2, 2006" }}
-					</time>
-					{{ with .Params.author }}
-						{{ if reflect.IsMap . }}
-							by <span class="p-author h-card">
-								{{ with .avatar }}<img src="{{ . }}" alt="{{ $.Params.author.full_name }}" class="author-avatar"> {{ end }}
-								{{ .full_name | default .name }}
-							</span>
-						{{ else }}
-							by <span class="p-author h-card">{{ . }}</span>
-						{{ end }}
-					{{ end }}
-					{{ if .Params.categories }}
-						<span class="post-categories">
-							{{ range .Params.categories }}
-								<a href="/categories/{{ . | urlize }}/" class="category-badge">{{ . }}</a>
+
+	<div class="updates-grid">
+		{{ range $displayPosts }}
+			<article class="h-entry post-card">
+				<a href="{{ .Permalink }}" class="post-card-link u-url">
+					{{ with .Params.photos }}
+						<div class="post-card-image">
+							<img src="{{ index . 0 }}" alt="" loading="lazy">
+							{{ if gt (len .) 1 }}
+								<span class="post-card-photocount">{{ len . }} photos</span>
 							{{ end }}
-						</span>
+						</div>
+					{{ else }}
+						<div class="post-card-placeholder"><span class="placeholder-icon">📄</span></div>
 					{{ end }}
-				</div>
-			</header>
 
-			<div class="p-summary post-summary">
-				{{ if .Content }}
-					<p>{{ .Content | plainify | htmlUnescape | truncate 300 }}</p>
-				{{ end }}
-			</div>
+					<div class="post-card-body">
+						{{ if .Title }}
+							<h3 class="p-name post-card-title">{{ .Title }}</h3>
+						{{ end }}
+						<time class="dt-published post-card-date" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">
+							{{ .Date.Format "January 2, 2006" }}
+						</time>
+						{{/* Build a clean excerpt: collapse whitespace, then strip the Wix-import
+						     boilerplate header ("<Title> <Author> Mon DD[, YYYY] N min read"
+						     + optional "Updated: …") that got baked into imported post bodies.
+						     Native micro.blog posts have no "min read", so they pass through. */}}
+						{{ $excerpt := .Content | plainify | htmlUnescape }}
+						{{ $excerpt = replaceRE `\s+` " " $excerpt }}
+						{{ $excerpt = replaceRE `(?i)^.*?[A-Z][a-z]+ \d{1,2}(,? \d{4})? \d+ min read ?` "" $excerpt }}
+						{{ $excerpt = replaceRE `(?i)^updated: [A-Z][a-z]+ \d{1,2}(,? \d{4})? ?` "" $excerpt }}
+						{{ $excerpt = $excerpt | strings.TrimSpace | truncate 150 }}
+						{{ with $excerpt }}
+							<p class="p-summary post-card-excerpt">{{ . }}</p>
+						{{ end }}
+						{{ if .Params.categories }}
+							<div class="post-card-cats">
+								{{ range first 4 .Params.categories }}
+									<span class="category-badge">{{ . }}</span>
+								{{ end }}
+							</div>
+						{{ end }}
+					</div>
+				</a>
+			</article>
+		{{ end }}
+	</div>
 
-			{{ if .Params.photos }}
-				<div class="post-photos-preview">
-					{{ range first 3 .Params.photos }}
-						<img src="{{ . }}" alt="" loading="lazy">
-					{{ end }}
-					{{ if gt (len .Params.photos) 3 }}
-						<span class="more-photos">+{{ sub (len .Params.photos) 3 }} more</span>
-					{{ end }}
-				</div>
-			{{ end }}
-
-			<div class="post-footer">
-				<a href="{{ .Permalink }}" class="u-url read-more">Read more →</a>
-			</div>
-		</article>
-	{{ end }}
-	
 	<!-- Pagination -->
-	<nav class="pagination">
+	<nav class="pagination" aria-label="Updates pagination">
 		<span class="pagination-info">
-			Showing {{ len $displayPosts }} of {{ len $allPosts }} total posts
+			Showing {{ len $displayPosts }} of {{ len $allPosts }} posts
 		</span>
 		<a href="/page/2/" class="pagination-next">Older posts →</a>
 	</nav>
+
 </div>
 
 {{ end }}

--- a/static/css/unified.css
+++ b/static/css/unified.css
@@ -187,6 +187,96 @@ h1, h2, h3, h4, h5, .section-heading, .post-card h3, .hero-title {
 }
 .post-card-placeholder .placeholder-icon { display: none; }
 
+/* ---------- Updates index: a museum "collection" grid of post-cards ----------
+   The template emits the .post-card contract above; these rules add only the
+   grid + card interior (chrome, imagery, title, date already inherit). */
+.updates-page .updates-header {
+  max-width: 46rem; margin: 0 auto 2.75rem; text-align: center;
+}
+.updates-page .updates-kicker {
+  display: inline-block; font-family: var(--wm-sans); text-transform: uppercase;
+  letter-spacing: .14em; font-size: .78rem; font-weight: 700;
+  color: var(--wm-ochre); margin-bottom: .6rem;
+}
+.updates-page .updates-header h1 {
+  font-family: var(--wm-serif); font-size: clamp(2.1rem, 5vw, 2.9rem);
+  line-height: 1.08; margin: 0 0 .75rem;
+}
+.updates-page .updates-lede {
+  font-size: 1.12rem; line-height: 1.6; color: var(--text-light); margin: 0;
+}
+
+/* category filter as warm pills */
+.updates-page .category-filter { margin: 0 auto 2.5rem; text-align: center; }
+.updates-page .category-links {
+  display: inline-flex; flex-wrap: wrap; justify-content: center; gap: .5rem;
+}
+.updates-page .category-link {
+  font-family: var(--wm-sans); font-size: .82rem; font-weight: 600;
+  color: var(--text-light); text-decoration: none;
+  padding: .38rem .9rem; border-radius: 50px;
+  background: var(--bg-white); border: 1px solid var(--border-color);
+  transition: color .15s, border-color .15s, background .15s;
+}
+.updates-page .category-link:hover,
+.updates-page .category-link.is-active {
+  color: #fff; background: var(--primary-color); border-color: var(--primary-color);
+}
+
+/* the collection grid */
+.updates-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem; margin: 0 0 3rem;
+}
+.updates-grid .post-card { display: flex; }
+.post-card-link {
+  display: flex; flex-direction: column; height: 100%;
+  text-decoration: none; color: inherit;
+}
+.post-card-body {
+  display: flex; flex-direction: column; gap: .55rem; flex: 1;
+  padding: 1.15rem 1.3rem 1.35rem;
+}
+.post-card-body .post-card-date { order: -1; }
+.post-card-body .post-card-title { font-size: 1.22rem; margin: 0; }
+.post-card-excerpt {
+  color: var(--text-light); font-size: .94rem; line-height: 1.55; margin: 0;
+}
+.post-card-cats { margin-top: auto; padding-top: .35rem; display: flex; flex-wrap: wrap; gap: .4rem; }
+.post-card-cats .category-badge {
+  font-family: var(--wm-sans); font-size: .68rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .05em;
+  color: var(--wm-clay); background: var(--bg-secondary);
+  border: 1px solid var(--border-color); border-radius: 50px;
+  padding: .15rem .6rem; text-decoration: none;
+}
+.post-card-cats .category-badge:hover { background: var(--wm-clay); color: #fff; border-color: var(--wm-clay); }
+.post-card-photocount {
+  position: absolute; right: .6rem; bottom: .6rem; z-index: 2;
+  font-family: var(--wm-sans); font-size: .7rem; font-weight: 700; color: #fff;
+  background: rgba(22,40,58,.72); border-radius: 50px; padding: .2rem .6rem;
+  backdrop-filter: blur(2px);
+}
+
+/* pagination footer */
+.updates-page .pagination {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 1rem;
+  border-top: 1px solid var(--border-color); padding-top: 1.5rem;
+}
+.updates-page .pagination-info {
+  font-family: var(--wm-sans); font-size: .82rem; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--text-light); font-weight: 600;
+}
+.updates-page .pagination-next {
+  font-family: var(--wm-sans); font-weight: 700; color: var(--link-color);
+  text-decoration: none;
+}
+.updates-page .pagination-next:hover { color: var(--primary-color); }
+@media (max-width: 560px) {
+  .updates-page .pagination { justify-content: center; text-align: center; }
+}
+
 /* ---------- Homepage: Pauwau promo + "Welcome Chief Cheryl" duo ---------- */
 .welcome-duo, .welcome-solo { max-width: 1200px; margin: 0 auto 2.5rem; }
 .welcome-duo {


### PR DESCRIPTION
## What
Rebuilds the **Updates** page (`/updates/`) to match the museum design language used across the rest of the site.

**Before:** the template emitted bespoke classes (`.post-preview`, `.post-title`, `.post-summary`) that `unified.css` never styled — so it rendered as a bland single-column text feed with no imagery or hierarchy.

**After:** a responsive **collection grid** built on the existing `.post-card` component — warm cards, sepia→color imagery on hover, ochre kicker dates, serif titles, a branded tribal-logo placeholder for text-only posts, `N photos` badges, and clay category badges. Adds an editorial header (kicker + serif title + lede) and a pill-style category filter.

Also strips the **Wix-import byline/read-time boilerplate** (`<Author> Mon DD N min read [Updated: …]`) from the card excerpts at render time. Native micro.blog posts (no "min read") pass through untouched.

## Where
- `layouts/_default/updates.html` — new grid markup + excerpt cleanup
- `static/css/unified.css` — grid + card-interior layout added to the design-system source of truth (dates/titles/imagery/placeholder already inherited)

## Testing
Verified locally with `just serve` + headless screenshots across photo posts, text-only posts, and native short posts — cruft stripped in all boilerplate variants, native posts unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)