### PR TITLE
feat(members): add Roll Access card to executive leadership tools

### DIFF
--- a/layouts/_default/members.html
+++ b/layouts/_default/members.html
@@ -188,6 +188,10 @@
                         <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-cash"/></svg>
                         <span class="exec-card-text"><span class="exec-card-title">Usage &amp; Cost</span><span class="exec-card-sub">Free-tier headroom &amp; backup health</span></span>
                     </a>
+                    <a href="/members/roll-access" class="exec-card" id="rollAccessBtn">
+                        <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-id"/></svg>
+                        <span class="exec-card-text"><span class="exec-card-title">Roll Access</span><span class="exec-card-sub">Who can edit the roll — leadership views, admins manage</span></span>
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Surfaces the new roll-access panel (`/members/roll-access`, shipped in members-service v2.0.9) in the **Executive leadership tools** grid on the member portal home.

- Visible to all leadership (the exec grid is already leader-gated) — transparency.
- The panel lets leadership **view** who can edit the roll; admin-tier managers (Doug, Chell, Cheryl) **grant/revoke**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)