### PR TITLE
Contacts UI: honor scoped 'editor' role

### DIFF
--- a/layouts/_default/contacts.html
+++ b/layouts/_default/contacts.html
@@ -179,6 +179,7 @@
       <div class="dir-addlist" style="margin-bottom:.8rem;">
         <input type="email" id="acc-email" placeholder="email@example.com" style="flex:2;padding:.45rem .6rem;border:1px solid #ccc;border-radius:6px;">
         <select id="acc-role" style="flex:1;padding:.45rem .6rem;border:1px solid #ccc;border-radius:6px;">
+          <option value="editor">Editor (add/edit contacts)</option>
           <option value="viewer">Viewer</option>
           <option value="counts">Counts-only</option>
         </select>

--- a/layouts/_default/members.html
+++ b/layouts/_default/members.html
@@ -188,6 +188,10 @@
                         <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-cash"/></svg>
                         <span class="exec-card-text"><span class="exec-card-title">Usage &amp; Cost</span><span class="exec-card-sub">Free-tier headroom &amp; backup health</span></span>
                     </a>
+                    <a href="/members/roll-access" class="exec-card" id="rollAccessBtn">
+                        <svg class="exec-card-icon" aria-hidden="true"><use href="#mi-id"/></svg>
+                        <span class="exec-card-text"><span class="exec-card-title">Roll Access</span><span class="exec-card-sub">Who can edit the roll — leadership views, admins manage</span></span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/static/js/contacts.js
+++ b/static/js/contacts.js
@@ -192,13 +192,16 @@
     document.documentElement.style.setProperty('--bar-h', h + 'px');
   }
   // ---------- role-based UI ----------
+  // canWrite = admin OR editor: create/edit contacts, lists, and list membership.
+  // Access management (dir-access-btn) stays admin-only.
   function applyRole() {
     const admin = myRole === 'admin';
-    const canSeePeople = admin || myRole === 'viewer';
-    ['dir-new', 'dir-new-list'].forEach(id => { const el = $(id); if (el) el.style.display = admin ? '' : 'none'; });
+    const canWrite = admin || myRole === 'editor';
+    const canSeePeople = canWrite || myRole === 'viewer';
+    ['dir-new', 'dir-new-list'].forEach(id => { const el = $(id); if (el) el.style.display = canWrite ? '' : 'none'; });
     const ab = $('dir-access-btn'); if (ab) ab.style.display = admin ? '' : 'none';
     const rb = $('dir-role-badge');
-    if (rb) rb.textContent = admin ? '' : (myRole === 'viewer' ? 'Read-only access' : 'Counts-only access');
+    if (rb) rb.textContent = canWrite ? '' : (myRole === 'viewer' ? 'Read-only access' : 'Counts-only access');
     $('dir-search').style.display = canSeePeople ? '' : 'none';
     if (!canSeePeople) {
       if (table) { table.destroy(); table = null; }
@@ -206,11 +209,11 @@
     }
   }
   function applyModalRole() {
-    const admin = myRole === 'admin';
-    ['f-first', 'f-last', 'f-org', 'f-title', 'f-email', 'f-phone', 'f-city', 'f-state', 'f-dnc'].forEach(id => { const el = $(id); if (el) el.disabled = !admin; });
-    $('f-save').style.display = admin ? '' : 'none';
-    const addRow = $('f-addlist').parentElement; if (addRow) addRow.style.display = admin ? '' : 'none';
-    if (!admin) $('f-lists').querySelectorAll('.dir-chip-x').forEach(x => x.style.display = 'none');
+    const canWrite = myRole === 'admin' || myRole === 'editor';
+    ['f-first', 'f-last', 'f-org', 'f-title', 'f-email', 'f-phone', 'f-city', 'f-state', 'f-dnc'].forEach(id => { const el = $(id); if (el) el.disabled = !canWrite; });
+    $('f-save').style.display = canWrite ? '' : 'none';
+    const addRow = $('f-addlist').parentElement; if (addRow) addRow.style.display = canWrite ? '' : 'none';
+    if (!canWrite) $('f-lists').querySelectorAll('.dir-chip-x').forEach(x => x.style.display = 'none');
   }
 
   // ---------- access management (admin) ----------


### PR DESCRIPTION
## What
`canWrite = admin || editor` lights up the add/edit contact + list controls for the new `editor` role. Access management stays admin-only. Adds an "Editor" option to the grant dropdown.

Pairs with waccamaw/contact-service editor-role backend change.

## Screenshots
UI change is additive/role-gated (shows existing write controls to a new role); no new visual components. Behavior verified against the contact-service API after deploy.